### PR TITLE
remove risk that token leaks

### DIFF
--- a/hooks/command
+++ b/hooks/command
@@ -59,7 +59,7 @@ if plugin_read_list_into_result CHECKS; then
 fi
 
 # Run Scorecard
-echo "Running: ${DOCKER_CMD}"
+echo "Running: docker run --rm -e GITHUB_AUTH_TOKEN=**** gcr.io/openssf/scorecard:${VERSION} --repo=${REPO_URL} --format=${FORMAT}${DOCKER_CMD#*--format=${FORMAT}}"
 if ! SCORECARD_RAW_OUTPUT=$(eval "${DOCKER_CMD}" 2>&1); then
   echo "❌ OSSF Scorecard failed:"
   echo "${SCORECARD_RAW_OUTPUT}"

--- a/hooks/command
+++ b/hooks/command
@@ -59,7 +59,6 @@ if plugin_read_list_into_result CHECKS; then
 fi
 
 # Run Scorecard
-echo "Running: docker run --rm -e GITHUB_AUTH_TOKEN=**** gcr.io/openssf/scorecard:${VERSION} --repo=${REPO_URL} --format=${FORMAT}${DOCKER_CMD#*--format=${FORMAT}}"
 if ! SCORECARD_RAW_OUTPUT=$(eval "${DOCKER_CMD}" 2>&1); then
   echo "❌ OSSF Scorecard failed:"
   echo "${SCORECARD_RAW_OUTPUT}"

--- a/tests/command.bats
+++ b/tests/command.bats
@@ -1,4 +1,5 @@
 #!/usr/bin/env bats
+# shellcheck disable=SC2030,SC2031
 
 setup() {
   load "${BATS_PLUGIN_PATH}/load.bash"


### PR DESCRIPTION
## Changes

- By outputting the Docker call we risk the token not being automatically redacted in Buildkite
